### PR TITLE
Optimize the comment about javaseClassLoader

### DIFF
--- a/java/org/apache/catalina/loader/WebappClassLoaderBase.java
+++ b/java/org/apache/catalina/loader/WebappClassLoaderBase.java
@@ -89,7 +89,7 @@ import org.apache.tomcat.util.security.PermissionCheck;
  * behavior may be completely different.
  * <p>
  * <strong>IMPLEMENTATION NOTE</strong> - By default, this class loader follows
- * the delegation model required by the specification. The system class
+ * the delegation model required by the specification. The bootstrap class
  * loader will be queried first, then the local repositories, and only then
  * delegation to the parent class loader will occur. This allows the web
  * application to override any shared class except the classes from J2SE.
@@ -1281,7 +1281,7 @@ public abstract class WebappClassLoaderBase extends URLClassLoader
                 return clazz;
             }
 
-            // (0.2) Try loading the class with the system class loader, to prevent
+            // (0.2) Try loading the class with the bootstrap class loader, to prevent
             //       the webapp from overriding Java SE classes. This implements
             //       SRV.10.7.2
             String resourceName = binaryNameToPath(name, false);


### PR DESCRIPTION
In HotSpot JVM, javaseClassLoader is actually Extension ClassLoader, The comment of javaseClassLoader mentioned:
```java
    /**
     * The bootstrap class loader used to load the JavaSE classes. In some
     * implementations this class loader is always <code>null</code> and in
     * those cases {@link ClassLoader#getParent()} will be called recursively on
     * the system class loader and the last non-null result used.
     */
    private ClassLoader javaseClassLoader;
```
So I think it is more appropriate to use bootstrap classLoader in the comments.